### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,9 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/cron-job-sample/security/code-scanning/1](https://github.com/conorheffron/cron-job-sample/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the workflow's tasks, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `security-events: write` for updating the dependency graph.

The `permissions` block will be added after the `name` field (line 9) to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
